### PR TITLE
Update Luraph SDK

### DIFF
--- a/luraphsdk.lua
+++ b/luraphsdk.lua
@@ -2,45 +2,60 @@
 -- will also perform basic runtime validation on script arguments
 
 local assert = assert
-local type = type
+local type = typeof or type
 local setfenv = setfenv
 
-LPH_ENCNUM = function(toEncrypt, ...)
-    assert(type(toEncrypt) == "number" and #{...} == 0, "LPH_ENCNUM only accepts a single constant double or integer as an argument.")
-    return toEncrypt
-end
-LPH_NUMENC = LPH_ENCNUM
+LPH_OBFUSCATED = false
+LPH_LINE = 0
 
-LPH_ENCSTR = function(toEncrypt, ...)
-    assert(type(toEncrypt) == "string" and #{...} == 0, "LPH_ENCSTR only accepts a single constant string as an argument.")
-    return toEncrypt
+function LPH_ENCFUNC(toEncrypt, encKey, decKey, ...)
+  local Types = {type(toEncrypt), type(encKey), type(decKey)}
+  assert(Types[1] == "function", "invalid argument #1 to 'LPH_ENCFUNC' (function expected, got " .. Types[1] .. ")")
+  assert(Types[2] == "string", "invalid argument #2 to 'LPH_ENCFUNC' (string expected, got " .. Types[2] .. ")")
+  assert(Types[3] == "string", "invalid argument #3 to 'LPH_ENCFUNC' (string expected, got " .. Types[3] .. ")")
+  assert(#{...} == 0, "LPH_ENCFUNC only takes 3 arguments.")
+  return toEncrypt
+end
+
+function LPH_ENCSTR(toEncrypt, ...)
+  local Types = {type(toEncrypt)}
+  assert(Types[1] == "string", "invalid argument #1 to 'LPH_ENCSTR' (string expected, got " .. Types[1] .. ")")
+  assert(#{...} == 0, "LPH_ENCSTR only takes 1 argument.")
+  return toEncrypt
 end
 LPH_STRENC = LPH_ENCSTR
 
-LPH_ENCFUNC = function(toEncrypt, encKey, decKey, ...)
-    -- not checking decKey value since this shim is meant to be used without obfuscation/whitelisting
-    assert(type(toEncrypt) == "function" and type(encKey) == "string" and #{...} == 0, "LPH_ENCFUNC accepts a constant function, constant string, and string variable as arguments.")
-    return toEncrypt
+function LPH_ENCNUM(toEncrypt, ...)
+  local Types = {type(toEncrypt)}
+  assert(Types[1] == "number", "invalid argument #1 to 'LPH_ENCNUM' (number expected, got " .. Types[1] .. ")")
+  assert(#{...} == 0, "LPH_ENCNUM only takes 1 argument.")
+  return toEncrypt
 end
-LPH_FUNCENC = LPH_ENCFUNC
+LPH_NUMENC = LPH_ENCNUM
 
-LPH_JIT = function(f, ...)
-    assert(type(f) == "function" and #{...} == 0, "LPH_JIT only accepts a single constant function as an argument.")
-    return f
+function LPH_CRASH(...)
+  assert(#{...} == 0, "LPH_CRASH does not take any arguments.")
+end
+
+function LPH_JIT(toEnhance, ...)
+  local Types = {type(toEnhance)}
+  assert(Types[1] == "function", "invalid argument #1 to 'LPH_JIT' (function expected, got " .. Types[1] .. ")")
+  assert(#{...} == 0, "LPH_JIT only takes 1 argument.")
+  return toEnhance
 end
 LPH_JIT_MAX = LPH_JIT
 
-LPH_NO_VIRTUALIZE = function(f, ...)
-    assert(type(f) == "function" and #{...} == 0, "LPH_NO_VIRTUALIZE only accepts a single constant function as an argument.")
-    return f
+function LPH_NO_VIRTUALIZE(toDevirtualize, ...)
+  local Types = {type(toDevirtualize)}
+  assert(Types[1] == "function", "invalid argument #1 to 'LPH_NO_VIRTUALIZE' (function expected, got " .. Types[1] .. ")")
+  assert(#{...} == 0, "LPH_NO_VIRTUALIZE only takes 1 argument.")
+  return toDevirtualize
 end
 
-LPH_NO_UPVALUES = function(f, ...)
-    assert(type(setfenv) == "function", "LPH_NO_UPVALUES can only be used on Lua versions with getfenv & setfenv")
-    assert(type(f) == "function" and #{...} == 0, "LPH_NO_UPVALUES only accepts a single constant function as an argument.")
-    return f
-end
-
-LPH_CRASH = function(...)
-    assert(#{...} == 0, "LPH_CRASH does not accept any arguments.")
+function LPH_NO_UPVALUES(toFix, ...)
+  local Types = {type(toFix)}
+  assert(type(setfenv) == "function", "LPH_NO_UPVALUES can only be used on Lua versions with getfenv & setfenv")
+  assert(Types[1] == "function", "invalid argument #1 to 'LPH_NO_UPVALUES' (function expected, got " .. Types[1] .. ")")
+  assert(#{...} == 0, "LPH_NO_UPVALUES only takes 1 argument.")
+  return toFix
 end


### PR DESCRIPTION
### Changes:
* Macro arguments now use names from the documentation
* Added LPH_LINE macro equal to `0`
* Added LPH_OBFUSCATED macro equal to `false`
* Added better error messages

### Error messages:
* Before
```lua
LPH_ENCNUM() -- LPH_ENCNUM only accepts a single constant double or integer as an argument.
LPH_ENCSTR() -- LPH_ENCSTR only accepts a single constant string as an argument.
--
LPH_ENCFUNC() -- LPH_ENCFUNC accepts a constant function, constant string, and string variable as arguments.
LPH_ENCFUNC(function() end) -- LPH_ENCFUNC accepts a constant function, constant string, and string variable as arguments.
LPH_ENCFUNC(function() end, "") -- LPH_ENCFUNC accepts a constant function, constant string, and string variable as arguments.
--
LPH_JIT() -- LPH_JIT only accepts a single constant function as an argument.
--
LPH_NO_VIRTUALIZE() -- LPH_NO_VIRTUALIZE only accepts a single constant function as an argument.
-- 
LPH_NO_UPVALUES() -- LPH_NO_UPVALUES only accepts a single constant function as an argument.
```
* After
```lua
LPH_ENCNUM() -- invalid argument #1 to 'LPH_ENCNUM' (number expected, got nil)
LPH_ENCSTR() -- invalid argument #1 to 'LPH_ENCSTR' (string expected, got nil)
--
LPH_ENCFUNC() -- invalid argument #1 to 'LPH_ENCFUNC' (function expected, got nil)
LPH_ENCFUNC(function() end) -- invalid argument #2 to 'LPH_ENCFUNC' (string expected, got nil)
LPH_ENCFUNC(function() end, "") -- invalid argument #3 to 'LPH_ENCFUNC' (string expected, got nil)
--
LPH_JIT() -- invalid argument #1 to 'LPH_JIT' (function expected, got nil)
--
LPH_NO_VIRTUALIZE() -- invalid argument #1 to 'LPH_NO_VIRTUALIZE' (function expected, got nil)
-- 
LPH_NO_UPVALUES() -- invalid argument #1 to 'LPH_NO_UPVALUES' (function expected, got nil)
```